### PR TITLE
Fixed the bug causing tasks to be moved too far down when placed unde…

### DIFF
--- a/src/Components/Board/Board.js
+++ b/src/Components/Board/Board.js
@@ -151,7 +151,7 @@ export function Board(props) {
                 }
                 //If dropped on a task
                 else {
-                    const insertIndex = panel.taskIds.indexOf(taskMove.targetTask);
+                    const insertIndex = newTaskIds.indexOf(taskMove.targetTask);
                     if(taskMove.position === 'over') {
                         newTaskIds.splice(insertIndex, 0, taskMove.taskId);
                     }

--- a/src/Components/Task/Task.js
+++ b/src/Components/Task/Task.js
@@ -50,13 +50,6 @@ export function Task(props) {
         }
     }
 
-    /* 
-        When a task is dropped on another, determine where that drop
-        happened so that you can determine if the new task should go
-        before or after the one that was already there. Then pass that
-        information with the task move object up to the board using
-        its moveTask function.
-    */
     const drop_handler = event => {
         event.preventDefault();
         const data = JSON.parse(event.dataTransfer.getData('text/plain'));


### PR DESCRIPTION
…rneath another. This was happening becauses moveTask in Board.js was removing the task being moved, and then the insert index was being obtained from the unmodified panel.taskIds array. This caused the task to be spliced into the modified array at the incorrect position.