### PR TITLE
Removed the 1em padding from TaskDivs and instead distributed it amon…

### DIFF
--- a/src/Components/Task/Task.css
+++ b/src/Components/Task/Task.css
@@ -1,6 +1,5 @@
 #TaskDiv {
     border: 1px solid black;
-    padding: 1em;
     background-color: #c0e0de;
     border-radius: 1em;
     width: 100%;
@@ -37,6 +36,8 @@
     width: 100%;
     border-bottom: 1px solid black;
     justify-content: space-between;
+    padding: 1em 1em 0.5em 1em;
+    box-sizing: border-box;
 }
 
 .TaskCloseButton {
@@ -62,12 +63,16 @@
     display: inline-flex;
     justify-content: space-between;
     width: 100%;
+    padding: 0 1em;
+    box-sizing: border-box;
 }
 
 #TaskCheckoffButton {
     display: inline-flex;
     justify-content: right;
     width: 100%;
+    padding: 0 1em 1em 1em;
+    box-sizing: border-box;
 }
 
 #TaskCheckoffButton span {
@@ -98,11 +103,17 @@
     outline-style: groove;
 }
 
+#TaskTitleForm{
+    width: 100%;
+}
+
 #TaskTitleInput {
     background-color: transparent;
     border: none;
     font-size: larger;
     font-weight: bold;
+    size: '';
+    width: 100%;
 }
 
 #TaskTitleInput:focus {

--- a/src/Components/Task/Task.js
+++ b/src/Components/Task/Task.js
@@ -85,12 +85,14 @@ export function Task(props) {
             onDrop={drop_handler}   
         >
             <div 
-                id='TaskDiv' 
                 className='Task'
-                draggable='true'
-                onDragStart={dragstart_handler}
+                id='TaskDiv' 
             >
-                <div id='TaskTitle'>
+                <div 
+                    id='TaskTitle'
+                    draggable='true'
+                    onDragStart={dragstart_handler}
+                >
                     {props.checkedOff ? 
                         <form id='TaskTitleForm'>
                             <input 
@@ -102,7 +104,7 @@ export function Task(props) {
                                 style={{textDecoration: 'line-through'}}
                             ></input>
                         </form> :
-                        <form>
+                        <form id='TaskTitleForm'>
                             <input 
                                 id='TaskTitleInput'
                                 type='text'
@@ -138,7 +140,11 @@ export function Task(props) {
                         </form>
                     }  
                 </div>
-                <div id='TaskCheckoffButton'><span onClick={handleCheckOff}>✓</span></div>
+                <div 
+                    id='TaskCheckoffButton'
+                    draggable='true'
+                    onDragStart={dragstart_handler}
+                ><span onClick={handleCheckOff}>✓</span></div>
             </div>
         </div>
     )


### PR DESCRIPTION
…g the three divs with each TaskDiv. This allows for the draggable attribute and onDragStart event listener to be placed on the TaskTitle and TaskCheckoffButton divs, avoiding the TaskContent div altogether, thus allowing the user to highlight the text they are typing in the description of each task.